### PR TITLE
Update intel_reports table schema

### DIFF
--- a/db/malshinon.sql
+++ b/db/malshinon.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS intel_reports(
       id INT PRIMARY KEY AUTO_INCREMENT,
       reporter_id INT,
       target_id INT,
-      text VARCHAR(255),
+      text TEXT,
       timestamp DATETIME DEFAULT CURRENT_TIMESTAMP(),
       FOREIGN KEY(reporter_id) REFERENCES people(id),
       FOREIGN KEY(target_id) REFERENCES people(id)

--- a/db/malshinon.sql
+++ b/db/malshinon.sql
@@ -15,8 +15,8 @@ CREATE TABLE IF NOT EXISTS people(
 -- CREATE TABLE IF NOT EXISTS intel_reports;
 CREATE TABLE IF NOT EXISTS intel_reports(
       id INT PRIMARY KEY AUTO_INCREMENT,
-      reporter_id INT,
-      target_id INT,
+      reporter_id INT NOT NULL,
+      target_id INT NOT NULL,
       text TEXT,
       timestamp DATETIME DEFAULT CURRENT_TIMESTAMP(),
       FOREIGN KEY(reporter_id) REFERENCES people(id),


### PR DESCRIPTION
- Change the `text` column type to `TEXT` for longer intelligence reports.
- Enforce `NOT NULL` constraints on `reporter_id` and `target_id` columns.